### PR TITLE
feat: Add panic recovery feature to HTTP server

### DIFF
--- a/apis/http_panic_recovery/http_panic_recovery.go
+++ b/apis/http_panic_recovery/http_panic_recovery.go
@@ -1,0 +1,9 @@
+package http_panic_recovery
+
+import "context"
+
+// Recovery is a behavior that an HTTP panic recovery feature (plugin)
+// must implement to be used inside the HTTP service implementation.
+type Recovery interface {
+	Recover(ctx context.Context)
+}

--- a/components/definition/definition.go
+++ b/components/definition/definition.go
@@ -44,8 +44,9 @@ type GrpcClient struct {
 }
 
 type HTTP struct {
-	DisableAuth      bool `toml:"disable_auth,omitempty" default:"false"`
-	HideErrorDetails bool `toml:"hide_error_details,omitempty"`
+	DisableAuth          bool `toml:"disable_auth,omitempty" default:"false"`
+	DisablePanicRecovery bool `toml:"disable_panic_recovery,omitempty" default:"false"`
+	HideErrorDetails     bool `toml:"hide_error_details,omitempty"`
 }
 
 type Deploy struct {

--- a/components/options/features.go
+++ b/components/options/features.go
@@ -16,4 +16,5 @@ const (
 	TracingFeatureName         = FeatureNamePrefix + "tracing"
 	TrackerFeatureName         = FeatureNamePrefix + "tracker"
 	LoggerExtractorFeatureName = FeatureNamePrefix + "logger_extractor"
+	PanicRecoveryFeatureName   = FeatureNamePrefix + "panic_recovery"
 )


### PR DESCRIPTION
Add a panic recovery feature to the HTTP server to handle panics gracefully and recover from them during request processing. This feature is configurable in the HTTP definition and can be disabled if needed.