### PR TITLE
feat: improve error API

### DIFF
--- a/apis/errors/errors.go
+++ b/apis/errors/errors.go
@@ -41,7 +41,7 @@ type ErrorFactory interface {
 // the error using the language error type.
 type Error interface {
 	// WithCode sets a custom error code to be added inside the error.
-	WithCode(code int32) Error
+	WithCode(code Code) Error
 
 	// WithAttributes adds a set o custom log attributes to be inserted into
 	// the log message.
@@ -50,4 +50,8 @@ type Error interface {
 	// Submit wraps the service error into a proper error type allowing the
 	// service to return it.
 	Submit(ctx context.Context) error
+}
+
+type Code interface {
+	ErrorCode() int32
 }

--- a/components/errors/errors.go
+++ b/components/errors/errors.go
@@ -8,7 +8,7 @@ import (
 
 // IsInternalError checks if an error is a framework Internal error.
 func IsInternalError(err error) bool {
-	if e, ok := isKnownError(err); ok {
+	if e, ok := IsKnownError(err); ok {
 		return e.Kind == merrors.KindInternal
 	}
 
@@ -17,7 +17,7 @@ func IsInternalError(err error) bool {
 
 // IsNotFoundError checks if an error is a framework NotFound error.
 func IsNotFoundError(err error) bool {
-	if e, ok := isKnownError(err); ok {
+	if e, ok := IsKnownError(err); ok {
 		return e.Kind == merrors.KindNotFound
 	}
 
@@ -26,7 +26,7 @@ func IsNotFoundError(err error) bool {
 
 // IsInvalidArgumentError checks if an error is a framework InvalidArgument error.
 func IsInvalidArgumentError(err error) bool {
-	if e, ok := isKnownError(err); ok {
+	if e, ok := IsKnownError(err); ok {
 		return e.Kind == merrors.KindValidation
 	}
 
@@ -35,7 +35,7 @@ func IsInvalidArgumentError(err error) bool {
 
 // IsPreconditionError checks if an error is a framework FailedPrecondition error.
 func IsPreconditionError(err error) bool {
-	if e, ok := isKnownError(err); ok {
+	if e, ok := IsKnownError(err); ok {
 		return e.Kind == merrors.KindPrecondition
 	}
 
@@ -44,7 +44,7 @@ func IsPreconditionError(err error) bool {
 
 // IsPermissionDeniedError checks if an error is a framework PermissionDenied error.
 func IsPermissionDeniedError(err error) bool {
-	if e, ok := isKnownError(err); ok {
+	if e, ok := IsKnownError(err); ok {
 		return e.Kind == merrors.KindPermission
 	}
 
@@ -53,7 +53,7 @@ func IsPermissionDeniedError(err error) bool {
 
 // IsCustomError checks if an error is a framework Custom error.
 func IsCustomError(err error) bool {
-	if e, ok := isKnownError(err); ok {
+	if e, ok := IsKnownError(err); ok {
 		return e.Kind == merrors.KindCustom
 	}
 
@@ -62,14 +62,14 @@ func IsCustomError(err error) bool {
 
 // IsRPCError checks if an error is a framework RPC error.
 func IsRPCError(err error) bool {
-	if e, ok := isKnownError(err); ok {
+	if e, ok := IsKnownError(err); ok {
 		return e.Kind == merrors.KindRPC
 	}
 
 	return false
 }
 
-func isKnownError(err error) (*merrors.Error, bool) {
+func IsKnownError(err error) (*merrors.Error, bool) {
 	var e *merrors.Error
 	ok := errors.As(err, &e)
 	return e, ok

--- a/internal/components/errors/factory.go
+++ b/internal/components/errors/factory.go
@@ -1,21 +1,10 @@
 package errors
 
 import (
-	"errors"
 	"fmt"
 
 	errorsApi "github.com/somatech1/mikros/apis/errors"
 	loggerApi "github.com/somatech1/mikros/apis/logger"
-)
-
-// Internal error codes.
-const (
-	CodeInternal int32 = iota + 1
-	CodeNotFound
-	CodeInvalidArgument
-	CodePreconditionFailed
-	CodeNoPermission
-	CodeRPC
 )
 
 // ErrorKind is an error representation of a mapped error.
@@ -53,12 +42,10 @@ func NewFactory(options FactoryOptions) *Factory {
 }
 
 // RPC sets that the current error is related to an RPC call with another gRPC
-// service (destination), However, it checks if the error is already a known
-// error, so it does not override it.
+// service (destination).
 func (f *Factory) RPC(err error, destination string) errorsApi.Error {
 	return newServiceError(&serviceErrorOptions{
 		HideDetails: f.hideMessageDetails,
-		Code:        CodeRPC,
 		Kind:        KindRPC,
 		ServiceName: f.serviceName,
 		Message:     "service RPC error",
@@ -73,7 +60,6 @@ func (f *Factory) RPC(err error, destination string) errorsApi.Error {
 func (f *Factory) InvalidArgument(err error) errorsApi.Error {
 	return newServiceError(&serviceErrorOptions{
 		HideDetails: f.hideMessageDetails,
-		Code:        CodeInvalidArgument,
 		Kind:        KindValidation,
 		ServiceName: f.serviceName,
 		Message:     "request validation failed",
@@ -87,12 +73,10 @@ func (f *Factory) InvalidArgument(err error) errorsApi.Error {
 func (f *Factory) FailedPrecondition(message string) errorsApi.Error {
 	return newServiceError(&serviceErrorOptions{
 		HideDetails: f.hideMessageDetails,
-		Code:        CodePreconditionFailed,
 		Kind:        KindPrecondition,
 		ServiceName: f.serviceName,
-		Message:     "failed precondition",
+		Message:     message,
 		Logger:      f.logger.Warn,
-		Error:       errors.New(message),
 	})
 }
 
@@ -101,7 +85,6 @@ func (f *Factory) FailedPrecondition(message string) errorsApi.Error {
 func (f *Factory) NotFound() errorsApi.Error {
 	return newServiceError(&serviceErrorOptions{
 		HideDetails: f.hideMessageDetails,
-		Code:        CodeNotFound,
 		Kind:        KindNotFound,
 		ServiceName: f.serviceName,
 		Message:     "not found",
@@ -114,7 +97,6 @@ func (f *Factory) NotFound() errorsApi.Error {
 func (f *Factory) Internal(err error) errorsApi.Error {
 	return newServiceError(&serviceErrorOptions{
 		HideDetails: f.hideMessageDetails,
-		Code:        CodeInternal,
 		Kind:        KindInternal,
 		ServiceName: f.serviceName,
 		Message:     "got an internal error",
@@ -128,7 +110,6 @@ func (f *Factory) Internal(err error) errorsApi.Error {
 func (f *Factory) PermissionDenied() errorsApi.Error {
 	return newServiceError(&serviceErrorOptions{
 		HideDetails: f.hideMessageDetails,
-		Code:        CodeNoPermission,
 		Kind:        KindPermission,
 		ServiceName: f.serviceName,
 		Message:     fmt.Sprintf("no permission to access %s", f.serviceName),

--- a/service.go
+++ b/service.go
@@ -494,7 +494,8 @@ func (s *Service) coupleClients(srv interface{}) error {
 			// members to these connections.
 
 			cOpts := &mgrpc.ClientConnectionOptions{
-				ServiceName: client.ServiceName,
+				ServiceName: s.definitions.ServiceName(),
+				ClientName:  client.ServiceName,
 				Context:     s.ctx,
 				Connection: mgrpc.ConnectionOptions{
 					Namespace: s.envs.CoupledNamespace,


### PR DESCRIPTION
- Removing internal error code to let service implementations handle this kind of information.

- Adjusting error parsing between service RPC calls to always send the right error to the caller.